### PR TITLE
Add basic property-based tests

### DIFF
--- a/TakeUntil/test/TakeUntil.Tests/TakeUntil.Tests.fsproj
+++ b/TakeUntil/test/TakeUntil.Tests/TakeUntil.Tests.fsproj
@@ -5,6 +5,7 @@
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="FsCheck" Version="3.1.0" />
         <PackageReference Include="FsUnit.xUnit" Version="7.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/TakeUntil/test/TakeUntil.Tests/take-until-tests.fs
+++ b/TakeUntil/test/TakeUntil.Tests/take-until-tests.fs
@@ -82,3 +82,26 @@ let ``if an array has matching element in the middle takeUntil returns an array 
 let ``if an array has matching element at the start takeUntil returns the fist element`` () =
     let array = [| 1..10 |] |> Array.takeUntil (fun x -> x = 1)
     Assert.True([| 1 |] = array)
+
+[<Fact>]
+let ``property-based test: sequence agrees with list model`` () =
+    let pred (x : int) = x % 2 = 0
+    let property (xs : int list) =
+        xs
+        |> Seq.takeUntil pred
+        |> Seq.toList
+        |> (=) (List.takeUntil pred xs)
+
+    FsCheck.Check.QuickThrowOnFailure property
+
+[<Fact>]
+let ``property-based test: sequence agrees with array model`` () =
+    let pred (x : int) = x % 2 = 0
+    let property (xs : FsCheck.NonNull<int[]>) =
+        let xs = xs.Get
+        xs
+        |> Seq.takeUntil pred
+        |> Seq.toArray
+        |> (=) (Array.takeUntil pred xs)
+
+    FsCheck.Check.QuickThrowOnFailure property


### PR DESCRIPTION
The library consists of three implementations of `Seq.takeUntil`, all of which are intended to be semantically identical. This commit adds basic tests that they are indeed semantically identical, for a specific choice of predicate.

---

Again, feel free to ignore this change; just noticed in passing that it would be trivial to add some pretty comprehensive correctness tests.